### PR TITLE
implement preview scrolling

### DIFF
--- a/docs/Search.md
+++ b/docs/Search.md
@@ -7,7 +7,7 @@ of various length for these words.
 But sometimes you need more advanced tools to get relevant results. Fortunately, `Rview`
 has something to offer:
 
-- `"<exact match>"`: Double quotes allows to search for exact matches.
+- `"<exact match>"`: Double quotes allow to search for exact matches.
 - `-"<exclude>"`: The minus before double quotes allows to exclude results
   that match the content inside these double quotes.
 

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -406,7 +406,7 @@
 				console.log("search index refresh is already in progress");
 				return;
 			}
-			if (!confirm("You are trying to refresh search indexes. This process can take a while. Are you sure?")) {
+			if (!confirm("The refresh of search indexes can take a while. Start the process?")) {
 				return;
 			}
 

--- a/static/templates/preview.html
+++ b/static/templates/preview.html
@@ -49,23 +49,50 @@
 		position: relative;
 	}
 
-	.preview-image {
+	.preview-carousel {
+		display: flex;
+		flex-flow: row nowrap;
+		height: 100%;
+		overflow-x: scroll;
+		scroll-snap-type: x mandatory;
+		scrollbar-width: none;
+		width: 100%;
+	}
+
+	/* Hide scrollbar in Safari and Chrome */
+	.preview-carousel::-webkit-scrollbar {
 		display: none;
-		position: fixed;
+	}
+
+	.preview-carousel-element {
+		flex: none;
+		position: relative;
+		scroll-snap-align: center;
+		scroll-snap-stop: always;
+		width: 100%;
+	}
+
+	.preview-image,
+	.preview-text,
+	.preview-audio,
+	.preview-video {
+		left: 50%;
+		position: absolute;
+		transform: translateX(-50%);
+	}
+
+	.preview-image {
 		object-fit: contain;
 	}
 
 	.preview-text {
 		border: 1px solid var(--border-color);
-		display: none;
 		margin: 0;
 		overflow-y: auto;
 		padding: 5px;
-		position: fixed;
 	}
 
 	.preview-audio {
-		display: none;
 		left: 50%;
 		position: absolute;
 		top: 50%;
@@ -74,40 +101,50 @@
 	}
 
 	.preview-video {
-		display: none;
-		position: fixed;
-		transform: translateY(-50%);
+		top: 50%;
+		transform: translate(-50%, -50%);
 	}
 
+	:root {
+		--switch-preview-button-size: 50px;
+	}
+
+	/*
+		We use "position: sticky" and "width: 0" to prevent buttons from
+		interfering with the scroll. We can't use non-zero width because it
+		creates extra space to scroll, that causes lags on mobile devices.
+	*/
 	.switch-preview-button {
+		height: 100%;
+		left: 0;
+		opacity: 0.3;
+		position: sticky;
+		width: 0;
+		z-index: 1;
+	}
+
+	.switch-preview-button a {
 		align-items: center;
 		display: flex;
 		justify-content: center;
 		height: 100%;
-		opacity: 0.3;
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
+		width: fit-content;
 	}
 
-	a.switch-preview-button:hover {
-		text-decoration: none;
+	.switch-preview-button svg {
+		height: var(--switch-preview-button-size);
+		width: var(--switch-preview-button-size);
 	}
 
-	.switch-preview-button>svg {
-		height: 50px;
-		width: 50px;
-	}
-
-	.switch-preview-button.prev>svg {
+	.switch-preview-button.prev svg {
 		transform: rotate(90deg);
 	}
 
 	.switch-preview-button.next {
-		right: 0;
+		left: calc(100% - var(--switch-preview-button-size));
 	}
 
-	.switch-preview-button.next>svg {
+	.switch-preview-button.next svg {
 		transform: rotate(270deg);
 	}
 
@@ -249,19 +286,42 @@
 
 	<div class="preview card">
 		<div class="preview-content">
-			<a href="#" class="icon-button switch-preview-button prev" title="Previous" onclick="swipePreview(-1); return false">
-				{{ embedIcon "chevron-down" }}
-			</a>
-			<a href="#" class="icon-button switch-preview-button next" title="Next" onclick="swipePreview(1); return false">
-				{{ embedIcon "chevron-down" }}
-			</a>
+			<div class="preview-carousel">
+				<div class="switch-preview-button prev">
+					<a href="#" class="icon-button" title="Previous" onclick="swipePreview(-1); return false">
+						{{ embedIcon "chevron-down" }}
+					</a>
+				</div>
+				<div class="switch-preview-button next">
+					<a href="#" class="icon-button" title="Next" onclick="swipePreview(1); return false">
+						{{ embedIcon "chevron-down" }}
+					</a>
+				</div>
 
-			<!-- TODO: add loader -->
+				{{ $index := 0 }}
+				{{ range .Entries }}
 
-			<img class="preview-image"></img>
-			<pre class="preview-text"></pre>
-			<audio class="preview-audio" controls></audio>
-			<video class="preview-video" controls></video>
+				{{ if not .CanPreview}}
+				{{ continue }}
+				{{ end }}
+
+				<div class="preview-carousel-element" id="preview-carousel-element-{{ $index }}" data-filename="{{ .Filename }}">
+					{{ if eq .FileType "image" }}
+					<!-- TODO: add loader -->
+					<img class="preview-image" src="{{ .ThumbnailURL }}" loading="lazy"></img>
+					{{ else if eq .FileType "text" }}
+					<pre class="preview-text"></pre>
+					{{ else if eq .FileType "audio" }}
+					<audio class="preview-audio" src="{{ .OriginalFileURL }}" controls></audio>
+					{{ else if eq .FileType "video" }}
+					<video class="preview-video" src="{{ .OriginalFileURL }}" controls></video>
+					{{ end }}
+				</div>
+
+				{{ $index = add $index 1 }}
+
+				{{ end }}
+			</div>
 		</div>
 
 		<div class="preview-side-panel">
@@ -315,15 +375,51 @@
 
 	const previewWrapper = document.getElementsByClassName("preview-wrapper")[0];
 	const previewContent = document.getElementsByClassName("preview-content")[0];
-	const previewImage = document.getElementsByClassName("preview-image")[0];
-	const previewText = document.getElementsByClassName("preview-text")[0];
-	const previewAudio = document.getElementsByClassName("preview-audio")[0];
-	const previewVideo = document.getElementsByClassName("preview-video")[0];
+	const previewCarousel = document.getElementsByClassName("preview-carousel")[0];
 	const fileInfos = document.getElementsByClassName("preview-file-info-value");
 	const previousPreviewButton = document.querySelector(".switch-preview-button.prev");
 	const nextPreviewButton = document.querySelector(".switch-preview-button.next");
 
 	const thumbnailIDPrefix = "selector-thumbnail-";
+	const previewElementIDPrefix = "preview-carousel-element-";
+
+	// Prevent scroll with middle mouse button.
+	previewCarousel.addEventListener("mousedown", ev => {
+		if (event.which === 2) {
+			ev.preventDefault();
+		}
+	});
+
+	// Sometimes rapid resize or orientation change can cause incorrect scroll position.
+	// So, we manually scroll to the correct preview.
+	window.addEventListener("resize", () => {
+		document.getElementById(previewElementIDPrefix + currentIndex).scrollIntoView({ behavior: "instant" });
+	});
+
+	// Update preview on scroll.
+	const observer = new IntersectionObserver(
+		(entries, opts) => {
+			if (!isPreviewOpened) {
+				return;
+			}
+			for (const entry of entries) {
+				// We always get intersectionRatio slightly less or more that a threshold value
+				// because the callback is called not immediately. So, we can simply use '>' to open
+				// a correct preview.
+				if (entry.intersectionRatio > 0.5) {
+					openPreview(entry.target.dataset.filename, false);
+					return;
+				}
+			}
+		},
+		{
+			root: previewContent,
+			threshold: 0.5
+		},
+	);
+	for (const elem of document.querySelectorAll(".preview-carousel-element")) {
+		observer.observe(elem);
+	}
 
 	// Set height of .preview-wrapper with JS as a workaround for this bug:
 	// https://bugzilla.mozilla.org/show_bug.cgi?id=1663634
@@ -338,28 +434,36 @@
 	// All attempts to set the right height for <pre> element using CSS have failed.
 	(
 		new ResizeObserver(() => {
-			// Use Math.max because one button can be hidden. If both buttons are hidden, use full width.
-			const halfMargin = Math.max(previousPreviewButton.clientWidth, nextPreviewButton.clientWidth);
+			const computedStyles = getComputedStyle(document.body);
+			const switchPreviewButtonSize = Number(computedStyles.getPropertyValue('--switch-preview-button-size').replace("px", ""));
 
 			const rect = previewContent.getBoundingClientRect();
 
-			for (const v of [previewImage, previewText, previewVideo]) {
-				v.style["height"] = `${rect.height}px`;
-				v.style["top"] = `${rect.top}px`;
-				v.style["width"] = `${rect.width - halfMargin * 2}px`;
-				v.style["left"] = `${rect.x + halfMargin}px`;
-			}
+			for (const elem of document.querySelectorAll(".preview-image,.preview-text,.preview-video,.preview-audio")) {
+				let height = `${rect.height}px`;
+				let maxHeight = "";
 
-			// Set "max-height" instead of "height" to avoid gap between controls and video.
-			previewVideo.style["height"] = "";
-			previewVideo.style["max-height"] = `${rect.height}px`;
-			// Center video vertically. Height of the video is taken into account by "translateY";
-			previewVideo.style["top"] = `${rect.top + rect.height / 2}px`;
+				switch (true) {
+					case elem.classList.contains("preview-video"):
+						// Set "max-height" instead of "height" to avoid gap between controls and video.
+						height = "";
+						maxHeight = `${rect.height}px`;
+						break;
+
+					case elem.classList.contains("preview-audio"):
+						height = "";
+						break;
+				}
+
+				elem.style["width"] = `${rect.width - switchPreviewButtonSize * 2}px`;;
+				elem.style["height"] = height;
+				elem.style["max-height"] = maxHeight;
+			}
 		})
 	).observe(previewContent);
 
 	const stopAnyPlayback = () => {
-		for (const v of [previewAudio, previewVideo]) {
+		for (const v of document.querySelectorAll(".preview-audio,.preview-video")) {
 			v.pause();
 			v.currentTime = 0;
 		}
@@ -369,8 +473,8 @@
 	let currentFilename = null;
 	let currentIndex = null;
 
-	const openPreview = (filename) => {
-		const ok = _openPreview(filename);
+	const openPreview = (filename, scroll = true) => {
+		const ok = _openPreview(filename, scroll);
 		if (!ok) {
 			// Just in case.
 			closePreview();
@@ -386,16 +490,16 @@
 
 	// _openPreview returns true when preview for a file with the passed name
 	// was successfully prepared. This function should be called only by "openPreview".
-	const _openPreview = (newFilename) => {
+	const _openPreview = (newFilename, scroll) => {
+		if (currentFilename === newFilename) {
+			// Everything should be already set.
+			return true;
+		}
+
 		const newIndex = entries.findIndex(v => v.filename == newFilename);
 		if (newIndex === -1) {
 			console.warn(`can't open preview for "${newFilename}": no such file with preview`);
 			return false;
-		}
-
-		if (currentFilename === newFilename) {
-			// Everything should be already set.
-			return true;
 		}
 
 		const oldFilename = currentFilename;
@@ -404,47 +508,37 @@
 
 		const entry = entries[currentIndex];
 
-		// Scroll to the chosen file.
+		// Scroll selector.
 		const thumbnailWrapper = document.getElementById(thumbnailIDPrefix + entry.filename);
 		const thumbnail = thumbnailWrapper.children[0];
 		const selector = thumbnailWrapper.parentElement;
-
 		selector.scrollLeft = thumbnail.offsetLeft - selector.offsetLeft + thumbnail.clientWidth / 2 - selector.clientWidth / 2;;
 
-		// Hide all previews.
-		previewImage.style["display"] = "";
-		previewText.style["display"] = "";
-		previewAudio.style["display"] = "";
-		previewVideo.style["display"] = "";
+		const previewElement = document.getElementById(previewElementIDPrefix + `${newIndex}`);
+
+		// Scroll previews.
+		if (scroll) {
+			previewElement.scrollIntoView({ behavior: "instant" });
+		}
 
 		stopAnyPlayback();
 
-		// Update preview.
-		switch (entry.file_type) {
-			case "image":
-				previewImage.style["display"] = "block";
-				previewImage.src = entry.thumbnail_url;
-				break;
+		// Load the file content.
+		if (entry.file_type === "text") {
+			(async () => {
+				const pre = previewElement.querySelector("pre");
 
-			case "audio":
-				previewAudio.style["display"] = "block";
-				previewAudio.src = entry.original_file_url;
-				break;
-
-			case "video":
-				previewVideo.style["display"] = "block";
-				previewVideo.src = entry.original_file_url;
-				break;
-
-			case "text":
-				previewText.style["display"] = "block";
-
-				if (entry.size > 3 << 20) {
-					previewText.innerHTML = `* File is too big to preview: ${entry.human_readable_size}`;
-					break;
+				if (pre.innerHTML) {
+					// The file content should be already downloaded.
+					return;
 				}
 
-				previewText.innerHTML = `* Loading "${entry.filename}"...\n`;
+				if (entry.size > 3 << 20) {
+					pre.innerHTML = `* File is too big to preview: ${entry.human_readable_size}`;
+					return;
+				}
+
+				pre.innerHTML = `* Loading "${entry.filename}"...\n`;
 
 				let statusCode = 0;
 				let textToShow = "";
@@ -459,13 +553,13 @@
 						if (statusCode != 200) {
 							textToShow = `* Error: ${textToShow}`;
 						} else {
-							previewText.innerHTML = "";
+							pre.innerHTML = "";
 						}
 
 						const escapedText = document.createTextNode(textToShow);
-						previewText.appendChild(escapedText);
+						pre.appendChild(escapedText);
 					});
-				break;
+			})();
 		}
 
 		// Update file info.
@@ -524,7 +618,7 @@
 			return;
 		}
 
-		openPreview(entries[newIndex].filename);
+		document.getElementById(previewElementIDPrefix + newIndex).scrollIntoView({ behavior: "instant" });
 	};
 
 	const closePreview = () => {

--- a/web/web.go
+++ b/web/web.go
@@ -162,6 +162,9 @@ func (s *Server) executeTemplate(w http.ResponseWriter, name string, data any) {
 	// significantly simplifies the development process.
 	template, err := template.New("base").
 		Funcs(template.FuncMap{
+			"add": func(a, b int) int {
+				return a + b
+			},
 			"prepareStaticLink": func(rawURL string) (string, error) {
 				hash := s.cfg.BuildInfo.ShortGitHash
 				if s.cfg.ReadStaticFilesFromDisk {


### PR DESCRIPTION
- Render all preview containers on server side instead of rendering only one
  container for every type of preview.
- Use `scroll-snap-*` CSS properties to stop scrolling at every preview
  container.